### PR TITLE
Add WCAG Large Text Compliance Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,8 @@ In addition to single contrast colors, **AccessibleColors** also offers a dynami
    myButton.TextColor = textColor;
    ```
 
+   By leveraging `GenerateAccessibleRamp`, `GetContrastColor`, `GetContrastColorForText`, and `IsTextCompliant`, you ensure that every UI element—whether a button state, icon, or text—remains accessible, readable, and adheres to WCAG guidelines, even as themes or background colors evolve.
+
 ## Example
 
 ```csharp

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ In addition to single contrast colors, **AccessibleColors** also offers a dynami
 
 ## Getting Started
 
-1. **Install**:
+1. **Install**: Add the library as a reference to your project. Since it's published on NuGet:
    ```bash
    dotnet add package AccessibleColors
    ```

--- a/README.md
+++ b/README.md
@@ -24,12 +24,12 @@ In addition to single contrast colors, **AccessibleColors** also offers a dynami
 
 ## Getting Started
 
-1. Install:
+1. **Install**:
    ```bash
    dotnet add package AccessibleColors
    ```
 
-2. Use for Single Contrast Colors:
+2. **Use for Single Contrast Colors**:
    ```csharp
    using AccessibleColors;
    using System.Drawing;
@@ -44,7 +44,7 @@ In addition to single contrast colors, **AccessibleColors** also offers a dynami
    bool isAccessible = WcagContrastColor.IsCompliant(background, foreground);
    ```
 
-3. Handling Text of Different Sizes and Weights:
+3. **Handling Text of Different Sizes and Weights**:
    ```csharp
    using AccessibleColors;
    using System.Drawing;
@@ -62,7 +62,7 @@ In addition to single contrast colors, **AccessibleColors** also offers a dynami
    // textForeground now provides a readable, accessible color for large text on the given background.
    ```
 
-4. Generate Accessible Color Ramps:
+4. **Generate Accessible Color Ramps**:
    ```csharp
    using AccessibleColors;
    using System.Drawing;
@@ -78,7 +78,7 @@ In addition to single contrast colors, **AccessibleColors** also offers a dynami
     // Use them for various UI states or theme elements.
    ```
 
-5. Integrate Into Your UI:
+5. **Integrate Into Your UI**:
 
     Use `etContrastColor` and `GenerateAccessibleRamp` anywhere you need accessible colors dynamically, custom themes, responsive adjustments, or design tools.
 

--- a/README.md
+++ b/README.md
@@ -15,21 +15,24 @@ In addition to single contrast colors, **AccessibleColors** also offers a dynami
 - **O(1) Performance (Single Contrast Calculation)**: Uses a precomputed lookup table (LUT) for sRGB-to-linear conversions, allowing instant single-color calculations.
 - **Dynamic Accessible Ramps**: Generate a sequence of WCAG-compliant colors from a single base color. The algorithm uses minimal searching and a few small adjustments to ensure compliance for every color in the ramp.
 - **No External Dependencies**: Relies only on `System.Drawing` types for colors, making integration straightforward.
-- **Simple API**: 
-  - A single `GetContrastColor` extension method on `Color` and an `IsCompliant` method let you easily ensure accessibility for individual colors.
-  - A `GenerateAccessibleRamp` method to produce an entire ramp of related colors that remain accessible.
+- **Simple API**:
+  - `GetContrastColor`: Instantly find a compliant foreground color for a given background.
+  - `IsCompliant`: Verify if a given foreground/background pair meets a required ratio.
+  - `GetContrastColorForText`: Consider text size and boldness to automatically choose a foreground color that meets large text or normal text WCAG rules.
+  - `IsTextCompliant`: Check if a given pair is compliant under WCAG rules for both normal and large/bold text conditions.
+  - `GenerateAccessibleRamp`: Produce an entire ramp of related colors that remain accessible.
 
 ## Getting Started
 
-1. **Install**: Add the library as a reference to your project. Since it's published on NuGet:
+1. Install:
    ```bash
    dotnet add package AccessibleColors
    ```
 
-2. **Use for Single Contrast Colors**:
+2. Use for Single Contrast Colors:
    ```csharp
-   using System.Drawing;
    using AccessibleColors;
+   using System.Drawing;
 
    // Suppose you have a background color:
    var background = Color.FromArgb(255, 0, 0); // Bright red
@@ -40,12 +43,30 @@ In addition to single contrast colors, **AccessibleColors** also offers a dynami
    // Check compliance explicitly if needed:
    bool isAccessible = WcagContrastColor.IsCompliant(background, foreground);
    ```
-   
-3. **Generate Accessible Color Ramps**:
-   ```csharp
-   using System.Drawing;
-   using AccessibleColors;
 
+3. Handling Text of Different Sizes and Weights:
+   ```csharp
+   using AccessibleColors;
+   using System.Drawing;
+
+   var bg = Color.FromArgb(32, 32, 32); // Dark background
+   double textSizePt = 18.0;  // At or above 18pt is considered large text by WCAG
+   bool isBold = false;       // If it were bold and >= 14pt, it would also be treated as large text
+
+   // Automatically choose a foreground color compliant for large text:
+   Color textForeground = WcagContrastColor.GetContrastColorForText(bg, textSizePt, isBold);
+
+   // Check if the chosen color meets WCAG contrast ratios for large text:
+   bool isTextCompliant = WcagContrastColor.IsTextCompliant(bg, textForeground, textSizePt, isBold);
+
+   // textForeground now provides a readable, accessible color for large text on the given background.
+   ```
+
+4. Generate Accessible Color Ramps:
+   ```csharp
+   using AccessibleColors;
+   using System.Drawing;
+   
    // Generate a 5-step ramp suitable for dark mode UI:
    Color baseColor = Color.FromArgb(0, 120, 215); // Your brand accent
    int steps = 5;
@@ -54,55 +75,68 @@ In addition to single contrast colors, **AccessibleColors** also offers a dynami
    IReadOnlyList<Color> ramp = AccessibleColors.GenerateAccessibleRamp(baseColor, steps, darkMode);
 
    // Each color in 'ramp' should meet WCAG compliance against the chosen background.
-   // Use them for various UI states or theme elements.
+    // Use them for various UI states or theme elements.
    ```
 
-4. **Integrate Into Your UI:**
+5. Integrate Into Your UI:
 
-    Use `GetContrastColor` and `GenerateAccessibleRamp` anywhere you need accessible colors dynamically—custom themes, responsive adjustments, or design tools.
-    
+    Use `etContrastColor` and `GenerateAccessibleRamp` anywhere you need accessible colors dynamically, custom themes, responsive adjustments, or design tools.
+
     For example:
+   ```csharp
+   // Suppose you have a brand accent color and you want to theme your app's buttons for dark mode.
+   // First, generate a 5-step accessible ramp:
+   var baseAccent = Color.FromArgb(0, 120, 215);
+   bool darkMode = true;
+   int steps = 5;
 
-    ```csharp
-    // Suppose you have a brand accent color and you want to theme your app's buttons for dark mode.
-    // First, generate a 5-step accessible ramp:
-    var baseAccent = Color.FromArgb(0, 120, 215);
-    bool darkMode = true;
-    int steps = 5;
+   IReadOnlyList<Color> accessibleRamp = AccessibleColors.GenerateAccessibleRamp(baseAccent, steps, darkMode);
 
-    IReadOnlyList<Color> accessibleRamp = AccessibleColors.GenerateAccessibleRamp(baseAccent, steps, darkMode);
+   // Now assign these ramp colors to different states of a custom button:
+   myButton.NormalColor = accessibleRamp[0];
+   myButton.HoverColor = accessibleRamp[1];
+   myButton.PressedColor = accessibleRamp[2];
+   myButton.FocusColor = accessibleRamp[3];
+   myButton.DisabledColor = accessibleRamp[4];
 
-    // Now assign these ramp colors to different states of a custom button:
-    myButton.NormalColor = accessibleRamp[0];
-    myButton.HoverColor = accessibleRamp[1];
-    myButton.PressedColor = accessibleRamp[2];
-    myButton.FocusColor = accessibleRamp[3];
-    myButton.DisabledColor = accessibleRamp[4];
+   // For icons or other elements over a known background, directly use GetContrastColor:
+   var bg = Color.FromArgb(32, 32, 32); // Dark background
+   var iconColor = bg.GetContrastColor(); 
+   bool isAccessibleIcon = WcagContrastColor.IsCompliant(bg, iconColor);
 
-    // Each color in the ramp maintains WCAG contrast standards against the chosen background,
-    // ensuring your button remains readable and visually consistent in all interactive states.
+   // Ensure the icon remains readable and accessible:
+   myIcon.ForeColor = iconColor;
 
-    // For icons, text, or other elements over a known background, directly use GetContrastColor:
-    var bg = Color.FromArgb(32, 32, 32); // Dark background
-    var iconColor = bg.GetContrastColor(); 
-    myIcon.ForeColor = iconColor; // Ensures the icon remains visible and accessible.
-    ```
+   // For text, consider text size and boldness using GetContrastColorForText:
+   double textSizePt = 18.0;
+   bool isBold = true;
+   var textColor = WcagContrastColor.GetContrastColorForText(myButton.NormalColor, textSizePt, isBold);
+   bool isTextAccessible = WcagContrastColor.IsTextCompliant(myButton.NormalColor, textColor, textSizePt, isBold);
 
-By leveraging `GenerateAccessibleRamp` and `GetContrastColor`, you ensure that every UI element—whether a button state or an icon—is accessible, readable, and adheres to WCAG guidelines, even as the theme or background colors change.
+   // Ensure the text remains readable and accessible:
+   myButton.TextColor = textColor;
+   ```
 
 ## Example
 
 ```csharp
-using System.Drawing;
 using AccessibleColors;
+using System.Drawing;
 
 // Single Contrast Example:
 var bg = Color.FromArgb(128,128,128); // Mid-gray background
 var fg = bg.GetContrastColor();
-
 Console.WriteLine($"Foreground: {fg}");
 bool compliant = WcagContrastColor.IsCompliant(bg, fg);
 Console.WriteLine($"Is compliant: {compliant}");
+
+// Text Compliance Example:
+var textBg = Color.FromArgb(32,32,32);
+var textSize = 18.0;
+var bold = true;
+var textFg = WcagContrastColor.GetContrastColorForText(textBg, textSize, bold);
+bool isTextCompliant = WcagContrastColor.IsTextCompliant(textBg, textFg, textSize, bold);
+Console.WriteLine($"Text Foreground: {textFg}, Is text compliant: {isTextCompliant}");
 
 // Ramp Example:
 var brandAccent = Color.FromArgb(50, 50, 50);
@@ -117,7 +151,7 @@ foreach (var c in rampColors)
 
 Accessibility is not just a nice-to-have; it's an essential part of building inclusive applications. Ensuring proper contrast ratios improves readability for everyone, including users with visual impairments. **AccessibleColors** automates these standards:
 
-- **Single Contrast Calculations**: Instantly determine a compliant foreground color for any given background.
+- **Single Contrast Calculations & Text-Aware Methods**: Instantly determine a compliant foreground color, factoring in text size and weight.
 - **Ramps for Theming**: Dynamically produce multiple related colors that all maintain compliance, streamlining UI state and theme development.
 
 ## Contributing

--- a/perf/AccessibleColors.Benchmarks/Program.cs
+++ b/perf/AccessibleColors.Benchmarks/Program.cs
@@ -1,5 +1,12 @@
 ﻿using AccessibleColors.Benchmarks;
 using BenchmarkDotNet.Running;
 
-BenchmarkRunner.Run<WcagContrastColorBenchmarks>(new Config());
-BenchmarkRunner.Run<ColorRampBenchmarks>(new Config());
+BenchmarkRunner.Run([
+    typeof(WcagContrastColorBenchmarks),
+    typeof(WcagContrastColorTextBenchmark),
+    typeof(ColorRampBenchmarks)],
+    new Config());
+
+//BenchmarkRunner.Run<WcagContrastColorBenchmarks>(new Config());
+//BenchmarkRunner.Run<WcagContrastColorTextBenchmark>(new Config());
+//BenchmarkRunner.Run<ColorRampBenchmarks>(new Config());

--- a/perf/AccessibleColors.Benchmarks/Program.cs
+++ b/perf/AccessibleColors.Benchmarks/Program.cs
@@ -6,7 +6,3 @@ BenchmarkRunner.Run([
     typeof(WcagContrastColorTextBenchmark),
     typeof(ColorRampBenchmarks)],
     new Config());
-
-//BenchmarkRunner.Run<WcagContrastColorBenchmarks>(new Config());
-//BenchmarkRunner.Run<WcagContrastColorTextBenchmark>(new Config());
-//BenchmarkRunner.Run<ColorRampBenchmarks>(new Config());

--- a/perf/AccessibleColors.Benchmarks/WcagContrastColorBenchmarks.cs
+++ b/perf/AccessibleColors.Benchmarks/WcagContrastColorBenchmarks.cs
@@ -3,40 +3,52 @@ using System.Drawing;
 
 namespace AccessibleColors.Benchmarks;
 
+/// <summary>
+/// Benchmarks for the GetContrastColor method without text size/weight considerations.
+/// </summary>
 [MemoryDiagnoser]
 public class WcagContrastColorBenchmarks
 {
-    private Color _cachedColor;
-    private Color _blackWhiteColor;
-    private Color _dynamicColor;
+    private Color _midGrayBackground;
+    private Color _darkGrayBackground;
+    private Color _mutedBlueBackground;
 
     [GlobalSetup]
     public void Setup()
     {
-        // Precompute a cached color
-        _cachedColor = Color.FromArgb(120, 120, 120); // Mid-gray
-        _blackWhiteColor = Color.FromArgb(20, 20, 20); // Dark gray
-        _dynamicColor = Color.FromArgb(100, 120, 140); // Muted blue
+        // Representative backgrounds:
+        _midGrayBackground = Color.FromArgb(120, 120, 120); // Mid-gray
+        _darkGrayBackground = Color.FromArgb(20, 20, 20);   // Dark gray
+        _mutedBlueBackground = Color.FromArgb(100, 120, 140); // Muted blue
 
-        // Warm up the cache
-        _cachedColor.GetContrastColor();
+        // Warm up:
+        _midGrayBackground.GetContrastColor();
     }
 
+    /// <summary>
+    /// Normal text scenario against a mid-gray background.
+    /// </summary>
     [Benchmark]
-    public Color GetContrastColor_CachedColor_O1WithCachingUnsafe()
+    public Color GetContrastColor_NormalText_MidGrayBg()
     {
-        return _cachedColor.GetContrastColor();
+        return _midGrayBackground.GetContrastColor();
     }
 
+    /// <summary>
+    /// Normal text scenario against a dark gray background.
+    /// </summary>
     [Benchmark]
-    public Color GetContrastColor_BlackWhiteContrast_O1WithCachingUnsafe()
+    public Color GetContrastColor_NormalText_DarkGrayBg()
     {
-        return _blackWhiteColor.GetContrastColor();
+        return _darkGrayBackground.GetContrastColor();
     }
 
+    /// <summary>
+    /// Normal text scenario against a muted blue background.
+    /// </summary>
     [Benchmark]
-    public Color GetContrastColor_DynamicContrast_O1WithCachingUnsafe()
+    public Color GetContrastColor_NormalText_MutedBlueBg()
     {
-        return _dynamicColor.GetContrastColor();
+        return _mutedBlueBackground.GetContrastColor();
     }
 }

--- a/perf/AccessibleColors.Benchmarks/WcagContrastColorTextBenchmark.cs
+++ b/perf/AccessibleColors.Benchmarks/WcagContrastColorTextBenchmark.cs
@@ -1,0 +1,50 @@
+﻿using BenchmarkDotNet.Attributes;
+using System.Drawing;
+
+namespace AccessibleColors.Benchmarks;
+
+/// <summary>
+/// Benchmarks the performance of GetContrastColorForText with varying text sizes and weights.
+/// </summary>
+[MemoryDiagnoser]
+public class WcagContrastColorTextBenchmark
+{
+    private Color _lightBackground;
+    private Color _darkBackground;
+    private Color _midBackground;
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        // Representative backgrounds:
+        _lightBackground = Color.FromArgb(255, 255, 255); // White
+        _darkBackground = Color.FromArgb(32, 32, 32);     // Dark gray
+        _midBackground = Color.FromArgb(120, 120, 120);   // Mid-gray
+
+        // Warm up by calling once:
+        _lightBackground.GetContrastColorForText(12.0, false);
+        _darkBackground.GetContrastColorForText(18.0, true);
+        _midBackground.GetContrastColorForText(14.0, true);
+    }
+
+    [Benchmark]
+    public Color GetContrastColorForText_NormalText_LightBg()
+    {
+        // Normal text on a light background
+        return _lightBackground.GetContrastColorForText(12.0, false);
+    }
+
+    [Benchmark]
+    public Color GetContrastColorForText_LargeBoldText_DarkBg()
+    {
+        // Large bold text on a dark background, should require only 3:1
+        return _darkBackground.GetContrastColorForText(18.0, true);
+    }
+
+    [Benchmark]
+    public Color GetContrastColorForText_Bold14ptText_MidBg()
+    {
+        // 14pt bold text on mid-gray background is considered large text at 3:1
+        return _midBackground.GetContrastColorForText(14.0, true);
+    }
+}

--- a/src/AccessibleColors/ColorRampGenerator.cs
+++ b/src/AccessibleColors/ColorRampGenerator.cs
@@ -1,5 +1,4 @@
 ﻿using System.Drawing;
-using System.Runtime.CompilerServices;
 
 namespace AccessibleColors;
 
@@ -16,7 +15,7 @@ public static class ColorRampGenerator
     public static IReadOnlyList<Color> GenerateAccessibleRamp(Color baseColor, int steps, bool darkMode)
     {
         if (steps <= 0)
-            return [];
+            Array.Empty<Color>();
 
         Color bg = darkMode ? Color.FromArgb(32, 32, 32) : Color.White;
         float bgLum = ColorUtilities.GetLuminance(bg);

--- a/src/AccessibleColors/WcagContrastColor.cs
+++ b/src/AccessibleColors/WcagContrastColor.cs
@@ -10,7 +10,7 @@ namespace AccessibleColors;
 /// </summary>
 public static class WcagContrastColor
 {
-    private const double RequiredRatio = 4.5;
+    //private const double RequiredRatio = 4.5;
 
     /// <summary>
     /// Returns a WCAG-compliant foreground color for the specified background color.
@@ -33,8 +33,8 @@ public static class WcagContrastColor
         double ratioBlack = ColorUtilities.CalculateContrastRatio(bgLum, 0.0f);
         double ratioWhite = ColorUtilities.CalculateContrastRatio(bgLum, 1.0f);
 
-        bool blackPasses = ratioBlack >= RequiredRatio;
-        bool whitePasses = ratioWhite >= RequiredRatio;
+        bool blackPasses = ratioBlack >= ColorUtilities.RequiredRatioNormalText;
+        bool whitePasses = ratioWhite >= ColorUtilities.RequiredRatioNormalText;
 
         if (blackPasses && whitePasses)
             return (ratioBlack > ratioWhite) ? Color.Black : Color.White;
@@ -45,14 +45,60 @@ public static class WcagContrastColor
     }
 
     /// <summary>
-    /// Determines whether the specified foreground color meets/exceeds
-    /// the given WCAG contrast ratio over the specified background color.
+    /// Returns a WCAG-compliant foreground color for the specified background color,
+    /// taking into account text size and weight, which may lower the required ratio from 4.5:1 to 3:1.
+    /// This ensures that large or bold large text can choose a suitable foreground just like normal text scenarios.
     /// </summary>
-    public static bool IsCompliant(Color background, Color foreground, double requiredRatio = RequiredRatio)
+    /// <param name="background">The background color.</param>
+    /// <param name="textSizePt">Text size in points.</param>
+    /// <param name="isBold">True if text is bold. 14pt bold is considered large text.</param>
+    /// <returns>A color meeting or exceeding the required ratio for the given text size and weight.</returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static Color GetContrastColorForText(this Color background, double textSizePt, bool isBold)
+    {
+        double required = ColorUtilities.GetRequiredRatioForText(textSizePt, isBold);
+        return ColorUtilities.GetContrastColorWithRatio(background, required);
+    }
+
+    /// <summary>
+    /// Determines whether the specified foreground and background color combination meets a given WCAG contrast ratio requirement.
+    /// By default, it checks against the normal text standard (4.5:1).
+    /// </summary>
+    /// <param name="background">The background <see cref="Color"/> to test against.</param>
+    /// <param name="foreground">The foreground <see cref="Color"/> to verify for compliance.</param>
+    /// <param name="requiredRatio">
+    /// The required WCAG contrast ratio. Defaults to <see cref="ColorUtilities.RequiredRatioNormalText"/> (4.5).
+    /// </param>
+    /// <returns>
+    /// <c>true</c> if the contrast ratio between <paramref name="background"/> and <paramref name="foreground"/> 
+    /// meets or exceeds <paramref name="requiredRatio"/>; otherwise, <c>false</c>.
+    /// </returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static bool IsCompliant(Color background, Color foreground, double requiredRatio = ColorUtilities.RequiredRatioNormalText)
     {
         float L_bg = ColorUtilities.GetLuminance(background);
         float L_fg = ColorUtilities.GetLuminance(foreground);
         double ratio = ColorUtilities.CalculateContrastRatio(L_bg, L_fg);
         return ratio >= requiredRatio;
+    }
+
+    /// <summary>
+    /// Determines if a given foreground and background color combination meets WCAG requirements,
+    /// considering the text size (in points) and whether it's bold.
+    /// 
+    /// WCAG rules:
+    /// - Normal text: ≥4.5:1
+    /// - Large text (≥18pt or ≥14pt bold): ≥3:1
+    /// </summary>
+    /// <param name="background">The background color.</param>
+    /// <param name="foreground">The foreground (text) color.</param>
+    /// <param name="textSizePt">Text size in points. E.g., 18 pt for large text.</param>
+    /// <param name="isBold">True if the text is bold. 14pt bold is considered large text.</param>
+    /// <returns>True if compliant under WCAG criteria for the given text size/weight, otherwise false.</returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static bool IsTextCompliant(Color background, Color foreground, double textSizePt, bool isBold)
+    {
+        double required = ColorUtilities.GetRequiredRatioForText(textSizePt, isBold);
+        return IsCompliant(background, foreground, required);
     }
 }


### PR DESCRIPTION
Fixes #6 

This pull request introduces `GetContrastColorForText` and `IsTextCompliant` methods to handle WCAG compliance for both normal and large/bold text. By considering text size and boldness, these methods ensure that colors meet either the standard 4.5:1 ratio for normal text or the 3:1 ratio for large/bold text.

**Key Changes:**
- `GetContrastColorForText`: Automatically selects a suitable foreground color based on background, text size, and boldness.
- `IsTextCompliant`: Validates whether a given foreground and background combination is WCAG-compliant for the specified text conditions.

These additions complement the existing `GetContrastColor` and `IsCompliant` methods, providing a more comprehensive suite of tools for ensuring accessible color choices in a variety of text scenarios.