### PR TITLE
Add WCAG Non-Text Contrast Support for UI Elements

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,13 +5,13 @@
 [![Build](https://github.com/willibrandon/AccessibleColors/actions/workflows/ci.yml/badge.svg)](https://github.com/willibrandon/AccessibleColors/actions/workflows/ci.yml)
 [![License](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
 
-**AccessibleColors** is a lightweight C# library that provides O(1) methods to compute WCAG-compliant contrast colors for foreground text or icons given a background color. It instantly returns a suitable foreground color that meets or exceeds the standard WCAG 2.2 contrast ratio of 4.5:1.
+**AccessibleColors** is a lightweight C# library that provides O(1) methods to compute WCAG-compliant contrast colors for foreground text, icons, and other UI elements given a background color. It instantly returns a suitable foreground color that meets or exceeds the standard WCAG 2.2 contrast ratio of 4.5:1 for normal text, or 3:1 for larger text or UI components.
 
 In addition to single contrast colors, **AccessibleColors** also offers a dynamic color ramp generator to produce a sequence ("ramp") of colors all meeting WCAG standards against a given background. This is especially useful for UI states (hover, pressed, disabled) or theming scenarios where you need multiple related accessible colors derived from a single base color.
 
 ## Key Features
 
-- **WCAG Compliance**: Ensures at least a 4.5:1 contrast ratio by default, helping you create accessible user interfaces.
+- **WCAG Compliance**: Ensures at least a 4.5:1 contrast ratio by default for normal text, and supports the 3:1 ratio for large text or UI elements, helping you create accessible user interfaces.
 - **O(1) Performance (Single Contrast Calculation)**: Uses a precomputed lookup table (LUT) for sRGB-to-linear conversions, allowing instant single-color calculations.
 - **Dynamic Accessible Ramps**: Generate a sequence of WCAG-compliant colors from a single base color. The algorithm uses minimal searching and a few small adjustments to ensure compliance for every color in the ramp.
 - **No External Dependencies**: Relies only on `System.Drawing` types for colors, making integration straightforward.
@@ -20,16 +20,18 @@ In addition to single contrast colors, **AccessibleColors** also offers a dynami
   - `IsCompliant`: Verify if a given foreground/background pair meets a required ratio.
   - `GetContrastColorForText`: Consider text size and boldness to automatically choose a foreground color that meets large text or normal text WCAG rules.
   - `IsTextCompliant`: Check if a given pair is compliant under WCAG rules for both normal and large/bold text conditions.
+  - `GetContrastColorForUIElement`: Obtain a compliant color for non-text UI elements (icons, focus rings, shapes) that often require a 3:1 ratio.
+  - `IsUIElementCompliant`: Verify if a UI element's foreground color meets the WCAG non-text contrast guideline.
   - `GenerateAccessibleRamp`: Produce an entire ramp of related colors that remain accessible.
 
 ## Getting Started
 
-1. **Install**: Add the library as a reference to your project. Since it's published on NuGet:
+1. **Install**:
    ```bash
    dotnet add package AccessibleColors
    ```
 
-2. **Use for Single Contrast Colors**:
+2. **Single Contrast Colors**:
    ```csharp
    using AccessibleColors;
    using System.Drawing;
@@ -56,58 +58,68 @@ In addition to single contrast colors, **AccessibleColors** also offers a dynami
    // Automatically choose a foreground color compliant for large text:
    Color textForeground = WcagContrastColor.GetContrastColorForText(bg, textSizePt, isBold);
 
-   // Check if the chosen color meets WCAG contrast ratios for large text:
+   // Check text compliance:
    bool isTextCompliant = WcagContrastColor.IsTextCompliant(bg, textForeground, textSizePt, isBold);
 
    // textForeground now provides a readable, accessible color for large text on the given background.
    ```
+4. **UI Elements (Non-Text) Contrast**:
+   ```csharp
+   using AccessibleColors;
+   using System.Drawing;
 
-4. **Generate Accessible Color Ramps**:
+   var uiBg = Color.FromArgb(240, 240, 240); // Light background
+
+   // Get a color that meets or exceeds the 3:1 ratio for UI elements:
+   Color uiElementColor = uiBg.GetContrastColorForUIElement(3.0);
+   bool isUIElementAccessible = WcagContrastColor.IsUIElementCompliant(uiBg, uiElementColor);
+
+   // Use uiElementColor for icons, focus indicators, or other graphical components 
+   // to ensure they're distinguishable and accessible.
+   ```
+
+5. **Generate Accessible Color Ramps**:
    ```csharp
    using AccessibleColors;
    using System.Drawing;
    
    // Generate a 5-step ramp suitable for dark mode UI:
-   Color baseColor = Color.FromArgb(0, 120, 215); // Your brand accent
+   Color baseAccent = Color.FromArgb(0, 120, 215); // Your brand accent
    int steps = 5;
    bool darkMode = true;
 
-   IReadOnlyList<Color> ramp = AccessibleColors.GenerateAccessibleRamp(baseColor, steps, darkMode);
+   IReadOnlyList<Color> ramp = AccessibleColors.GenerateAccessibleRamp(baseAccent, steps, darkMode);
 
-   // Each color in 'ramp' should meet WCAG compliance against the chosen background.
-   // Use them for various UI states or theme elements.
+   // Use these ramp colors for various UI states, ensuring each remains accessible.
    ```
 
-5. **Integrate Into Your UI**:
-
-    Use `GetContrastColor`, `GenerateAccessibleRamp`, `GetContrastColorForText`, and `IsTextCompliant` anywhere you need accessible colors dynamically, custom themes, responsive adjustments, or design tools.
+5. **Integrating Into Your UI**:
 
     For example:
    ```csharp
-   // Suppose you have a brand accent color and you want to theme your app's buttons for dark mode.
-   // First, generate a 5-step accessible ramp:
+   // Suppose you want to theme your app's buttons for dark mode.
    var baseAccent = Color.FromArgb(0, 120, 215);
    bool darkMode = true;
    int steps = 5;
 
    IReadOnlyList<Color> accessibleRamp = AccessibleColors.GenerateAccessibleRamp(baseAccent, steps, darkMode);
 
-   // Now assign these ramp colors to different states of a custom button:
+   // Assign ramp colors to different states of a custom button:
    myButton.NormalColor = accessibleRamp[0];
    myButton.HoverColor = accessibleRamp[1];
    myButton.PressedColor = accessibleRamp[2];
    myButton.FocusColor = accessibleRamp[3];
    myButton.DisabledColor = accessibleRamp[4];
 
-   // For icons or other elements over a known background, directly use GetContrastColor:
-   var bg = Color.FromArgb(32, 32, 32); // Dark background
-   var iconColor = bg.GetContrastColor(); 
-   bool isAccessibleIcon = WcagContrastColor.IsCompliant(bg, iconColor);
+   // For icons or other UI elements:
+   var bg = Color.FromArgb(32, 32, 32); 
+   var iconColor = bg.GetContrastColorForUIElement(); // Defaults to 3:1 for non-text
+   bool isAccessibleIcon = WcagContrastColor.IsUIElementCompliant(bg, iconColor);
 
    // Ensure the icon remains readable and accessible:
    myIcon.ForeColor = iconColor;
 
-   // For text, consider text size and boldness using GetContrastColorForText:
+   // For text with size/weight considerations:
    double textSizePt = 18.0;
    bool isBold = true;
    var textColor = WcagContrastColor.GetContrastColorForText(myButton.NormalColor, textSizePt, isBold);
@@ -117,7 +129,7 @@ In addition to single contrast colors, **AccessibleColors** also offers a dynami
    myButton.TextColor = textColor;
    ```
 
-   By leveraging `GenerateAccessibleRamp`, `GetContrastColor`, `GetContrastColorForText`, and `IsTextCompliant`, you ensure that every UI element-whether a button state, icon, or text-remains accessible, readable, and adheres to WCAG guidelines, even as themes or background colors evolve.
+   By leveraging all these methods, you can ensure that every UI element, text, icons, focus indicators, stateful ramps, remains readable, accessible, and fully WCAG-compliant as themes or background colors evolve.
 
 ## Example
 
@@ -140,6 +152,12 @@ var textFg = WcagContrastColor.GetContrastColorForText(textBg, textSize, bold);
 bool isTextCompliant = WcagContrastColor.IsTextCompliant(textBg, textFg, textSize, bold);
 Console.WriteLine($"Text Foreground: {textFg}, Is text compliant: {isTextCompliant}");
 
+// UI Element Compliance Example:
+var uiBg = Color.FromArgb(240, 240, 240);
+var uiElementColor = uiBg.GetContrastColorForUIElement(); // 3:1 by default
+bool isUIElementAccessible = WcagContrastColor.IsUIElementCompliant(uiBg, uiElementColor);
+Console.WriteLine($"UI Element Foreground: {uiElementColor}, Is UI compliant: {isUIElementAccessible}");
+
 // Ramp Example:
 var brandAccent = Color.FromArgb(50, 50, 50);
 var rampColors = AccessibleColors.GenerateAccessibleRamp(brandAccent, 5, darkMode: false);
@@ -151,10 +169,7 @@ foreach (var c in rampColors)
 
 ## Why This Matters
 
-Accessibility is not just a nice-to-have; it's an essential part of building inclusive applications. Ensuring proper contrast ratios improves readability for everyone, including users with visual impairments. **AccessibleColors** automates these standards:
-
-- **Single Contrast Calculations & Text-Aware Methods**: Instantly determine a compliant foreground color, factoring in text size and weight.
-- **Ramps for Theming**: Dynamically produce multiple related colors that all maintain compliance, streamlining UI state and theme development.
+Accessibility is essential for building inclusive applications. Ensuring proper contrast ratios improves readability and usability for everyone. **AccessibleColors** automates these standards for both text and non-text UI elements, allowing you to quickly achieve compliance with WCAG guidelines without manual guesswork.
 
 ## Contributing
 

--- a/perf/AccessibleColors.Benchmarks/Program.cs
+++ b/perf/AccessibleColors.Benchmarks/Program.cs
@@ -4,5 +4,6 @@ using BenchmarkDotNet.Running;
 BenchmarkRunner.Run([
     typeof(WcagContrastColorBenchmarks),
     typeof(WcagContrastColorTextBenchmark),
+    typeof(WcagContrastColorUIElementBenchmark),
     typeof(ColorRampBenchmarks)],
     new Config());

--- a/perf/AccessibleColors.Benchmarks/WcagContrastColorUIElementBenchmark.cs
+++ b/perf/AccessibleColors.Benchmarks/WcagContrastColorUIElementBenchmark.cs
@@ -1,0 +1,56 @@
+﻿using BenchmarkDotNet.Attributes;
+using System.Drawing;
+
+namespace AccessibleColors.Benchmarks;
+
+/// <summary>
+/// Benchmarks the performance of GetContrastForUIElement with various backgrounds
+/// representing common UI element scenarios.
+/// 
+/// This test assumes that the UI element compliance defaults to a ratio of 3:1
+/// (or another ratio as defined by the UI requirements) rather than the stricter 4.5:1 for text.
+/// It's intended to show how quickly we can get a suitable color for UI elements like icons,
+/// graphical components, and other non-text controls.
+/// </summary>
+[MemoryDiagnoser]
+public class WcagContrastColorUIElementBenchmark
+{
+    private Color _lightBackground;
+    private Color _darkBackground;
+    private Color _midBackground;
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        // Representative backgrounds:
+        _lightBackground = Color.FromArgb(255, 255, 255); // White (typical light UI)
+        _darkBackground = Color.FromArgb(32, 32, 32);     // Dark gray (typical dark UI)
+        _midBackground = Color.FromArgb(120, 120, 120);   // Mid-gray
+
+        // Warm up by calling once:
+        WcagContrastColor.GetContrastColorForUIElement(_lightBackground);
+        WcagContrastColor.GetContrastColorForUIElement(_darkBackground);
+        WcagContrastColor.GetContrastColorForUIElement(_midBackground);
+    }
+
+    [Benchmark]
+    public Color GetContrastForUIElement_LightBg()
+    {
+        // UI element over a light background
+        return WcagContrastColor.GetContrastColorForUIElement(_lightBackground);
+    }
+
+    [Benchmark]
+    public Color GetContrastForUIElement_DarkBg()
+    {
+        // UI element over a dark background
+        return WcagContrastColor.GetContrastColorForUIElement(_darkBackground);
+    }
+
+    [Benchmark]
+    public Color GetContrastForUIElement_MidBg()
+    {
+        // UI element over a mid-gray background
+        return WcagContrastColor.GetContrastColorForUIElement(_midBackground);
+    }
+}

--- a/src/AccessibleColors/AccessibleColors.csproj
+++ b/src/AccessibleColors/AccessibleColors.csproj
@@ -4,7 +4,6 @@
 		<TargetFrameworks>net8.0;net9.0</TargetFrameworks>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
-		<AllowUnsafeBlocks>true</AllowUnsafeBlocks>
 		<Deterministic>true</Deterministic>
 	</PropertyGroup>
 

--- a/src/AccessibleColors/ColorUtilities.cs
+++ b/src/AccessibleColors/ColorUtilities.cs
@@ -12,14 +12,14 @@ internal static class ColorUtilities
 {
     internal const double RequiredRatioNormalText = 4.5;
     internal const double RequiredRatioLargeText = 3.0;
+    internal const double RequiredRatioUIElement = 3.0;
 
     private const float Xn = 0.95047f;
     private const float Yn = 1.00000f;
     private const float Zn = 1.08883f;
 
-    // Precompute LUT for sRGB -> linear once (from WcagContrastColor logic)
+    // Precompute LUT for sRGB -> linear once
     private static readonly float[] sRGBToLinear;
-    private static readonly IntPtr sRGBToLinearPtr;
 
     static ColorUtilities()
     {
@@ -28,14 +28,6 @@ internal static class ColorUtilities
         {
             float v = i / 255f;
             sRGBToLinear[i] = NormalizeSrgbComponent(v);
-        }
-
-        unsafe
-        {
-            fixed (float* p = sRGBToLinear)
-            {
-                sRGBToLinearPtr = (IntPtr)p;
-            }
         }
     }
 
@@ -229,14 +221,11 @@ internal static class ColorUtilities
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     internal static float GetLuminance(Color c)
     {
-        unsafe
-        {
-            float* lut = (float*)sRGBToLinearPtr;
-            float r = lut[c.R];
-            float g = lut[c.G];
-            float b = lut[c.B];
-            return 0.2126f * r + 0.7152f * g + 0.0722f * b;
-        }
+        // Directly access the sRGBToLinear array:
+        float r = sRGBToLinear[c.R];
+        float g = sRGBToLinear[c.G];
+        float b = sRGBToLinear[c.B];
+        return 0.2126f * r + 0.7152f * g + 0.0722f * b;
     }
 
     /// <summary>

--- a/src/AccessibleColors/WcagContrastColor.cs
+++ b/src/AccessibleColors/WcagContrastColor.cs
@@ -61,6 +61,19 @@ public static class WcagContrastColor
     }
 
     /// <summary>
+    /// Returns a WCAG-compliant foreground color for UI elements (non-text) given a background color.
+    /// Non-text elements often need at least 3:1 contrast ratio to be distinguishable.
+    /// </summary>
+    /// <param name="background">The background color.</param>
+    /// <param name="requiredRatio">The required ratio for non-text elements, defaults to 3.0.</param>
+    /// <returns>A color that meets or exceeds the specified ratio for non-text UI elements.</returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static Color GetContrastColorForUIElement(this Color background, double requiredRatio = ColorUtilities.RequiredRatioUIElement)
+    {
+        return ColorUtilities.GetContrastColorWithRatio(background, requiredRatio);
+    }
+
+    /// <summary>
     /// Determines whether the specified foreground and background color combination meets a given WCAG contrast ratio requirement.
     /// By default, it checks against the normal text standard (4.5:1).
     /// </summary>
@@ -100,5 +113,22 @@ public static class WcagContrastColor
     {
         double required = ColorUtilities.GetRequiredRatioForText(textSizePt, isBold);
         return IsCompliant(background, foreground, required);
+    }
+
+    /// <summary>
+    /// Determines if a UI element or graphical object meets the WCAG contrast recommendation
+    /// (usually at least 3:1) against the specified background.
+    /// Useful for icons, focus indicators, or essential UI boundaries.
+    /// </summary>
+    /// <param name="background">The background color.</param>
+    /// <param name="elementColor">The UI element (foreground) color.</param>
+    /// <param name="requiredRatio">
+    /// The required WCAG ratio for non-text elements. Defaults to 3.0.
+    /// </param>
+    /// <returns>True if compliant, false otherwise.</returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static bool IsUIElementCompliant(Color background, Color elementColor, double requiredRatio = ColorUtilities.RequiredRatioUIElement)
+    {
+        return IsCompliant(background, elementColor, requiredRatio);
     }
 }

--- a/tests/AccessibleColors.Tests/WcagContrastColorTests.cs
+++ b/tests/AccessibleColors.Tests/WcagContrastColorTests.cs
@@ -72,6 +72,14 @@ public class WcagContrastColorTests
     }
 
     [Fact]
+    public void GetContrastColorForUIElement_ReturnsCompliantColor()
+    {
+        var background = Color.FromArgb(50, 50, 50);
+        var uiColor = background.GetContrastColorForUIElement(); // Should meet ≥3:1 by default
+        Assert.True(WcagContrastColor.IsUIElementCompliant(background, uiColor));
+    }
+
+    [Fact]
     public void IsCompliant_BlackOnWhite_ShouldPass()
     {
         var background = Color.White;
@@ -108,6 +116,22 @@ public class WcagContrastColorTests
         var foreground = Color.Red;
         Assert.False(WcagContrastColor.IsCompliant(background, foreground),
             "Red text on white background typically fails the 4.5:1 ratio for normal text.");
+    }
+
+    [Theory]
+    [InlineData(32, 32, 32, 120, 120, 120, true)]  // Gray on dark should be around or above 3:1
+    [InlineData(255, 255, 255, 200, 200, 200, false)] // Light gray on white may fail 3:1
+    public void IsUIElementCompliant_ValidatesNonTextContrast(
+            int br, int bg, int bb,
+            int fr, int fg, int fb,
+            bool expected)
+    {
+        var background = Color.FromArgb(br, bg, bb);
+        var element = Color.FromArgb(fr, fg, fb);
+
+        bool actual = WcagContrastColor.IsUIElementCompliant(background, element);
+
+        Assert.Equal(expected, actual);
     }
 
     [Theory]
@@ -188,6 +212,15 @@ public class WcagContrastColorTests
 
         Assert.True(IsWCAGCompliant(input, contrastColor, RequiredRatio),
             $"Contrast color {contrastColor} did not meet ~4.5:1 ratio for near-threshold gray {input}.");
+    }
+
+    [Fact]
+    public void UIElementOnVeryBrightBg_StillFindsCompliantColor()
+    {
+        var background = Color.FromArgb(250, 250, 250);
+        var uiColor = background.GetContrastColorForUIElement();
+
+        Assert.True(WcagContrastColor.IsUIElementCompliant(background, uiColor));
     }
 
     /// <summary>


### PR DESCRIPTION
Fixes #8 

This pull request introduces support for ensuring WCAG-compliant contrast ratios (≥3:1) for non-text UI components. In addition to handling text contrast (4.5:1 for normal, 3:1 for large/bold text), the library now provides:

- `GetContrastColorForUIElement`: Obtain a compliant foreground color for non-text UI elements (icons, focus rings, shapes) based on a specified ratio (3:1 by default).
- `IsUIElementCompliant`: Verify if a chosen UI element foreground color meets the WCAG non-text contrast guideline.

The README has been updated with examples demonstrating how to use these new features to improve accessibility for icons, focus indicators, and other graphical objects.